### PR TITLE
Is 'long|!' a valid option syntax?

### DIFF
--- a/mytop
+++ b/mytop
@@ -156,7 +156,7 @@ GetOptions(
     "idle|i"              => \$config{idle},
     "resolve|r"           => \$config{resolve},
     "prompt!"             => \$config{prompt},
-    "long|!"              => \$config{long_nums},
+    "long!"               => \$config{long_nums},
     "mode|m=s"            => \$config{mode},
     "sort=s"              => \$config{sort},
 );


### PR DESCRIPTION
Hi Jeremy,

I had to apply this tiny fix, or mytop 1.7 wouldn't start on my test systems.
Not sure if it's valid or invalid syntax though.

Thanks for mytop,
