### PR TITLE
Tiny fix to idle Getopt::Long definition.

### DIFF
--- a/mytop
+++ b/mytop
@@ -153,7 +153,7 @@ GetOptions(
     "delay|s=i"           => \$config{delay},
     "batch|batchmode|b"   => \$config{batchmode},
     "header!"             => \$config{header},
-    "idle|i"              => \$config{idle},
+    "idle|i!"              => \$config{idle},
     "resolve|r"           => \$config{resolve},
     "prompt!"             => \$config{prompt},
     "long!"               => \$config{long_nums},


### PR DESCRIPTION
The idle command is documented as being negatable.  However the
 Getopt::Long definition didn't actually support this.

This is a one character fix to add '!' to the 'idle' line to make
the --noidle argument work.
