### PR TITLE
mytop - fix specifying filters in .mytop

### DIFF
--- a/mytop
+++ b/mytop
@@ -129,7 +129,12 @@ if (-e $config)
 
 	    if (/(\S+)\s*=\s*(.*\S)/)
             {
-                $config{lc $1} = $2 if exists $config{lc $1};
+               my ($k, $v) = ($1, $2);
+               if ($k =~ /^filter_/i) {
+                 $config{lc $k} = StringOrRegex($v) if exists $config{lc $k};
+               } else {
+                  $config{lc $k} = $v if exists $config{lc $k};
+               }
             }
         }
         close CFG;


### PR DESCRIPTION
Edit: I just realized this doesn't have the status field, which was added by another author in a later release.  Closing - this version is rather old.

Specifying filters (filter_status, filter_user, etc) in the mytop config previously wouldn't work, because any filter specified here was added to the config hash as a literal string.  This change fixes that - if filter_* is defined in the config and matches an existing filter_* key, then run the value through StringOrRegex() and assign to the config hash.